### PR TITLE
fabric api Modify how items are registered

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version = 1.19.2
-yarn_mappings = 1.19.2+build.1
-loader_version = 0.14.8
+minecraft_version = 1.19.3
+yarn_mappings = 1.19.3+build.1
+loader_version = 0.14.18
 
 # Mod Properties
-mod_version = 1.0.3+mc1.19.2
+mod_version = 1.0.3+mc1.19.3
 maven_group = committee.nova
 archives_base_name = MinersLunchbox-fabric
 
 # Dependencies
-fabric_version = 0.58.6+1.19.2
+fabric_version = 0.76.0+1.19.3
 itemnbt_version = 3.4

--- a/minepkg.toml
+++ b/minepkg.toml
@@ -6,7 +6,7 @@ manifestVersion = 0
   type = "mod"
   name = "minerslunchbox"
   description = "Lunchbox, yum"
-  version = "1.0.3+mc1.19.2"
+  version = "1.0.3+mc1.19.3"
   platform = "fabric"
   license = "MIT"
   source = "https://github.com/Nova-Committee/MinersLunchbox"
@@ -15,7 +15,7 @@ manifestVersion = 0
 # These are global requirements
 [requirements]
   minecraft = "~1.19"
-  fabricLoader = ">=0.14.6"
+  fabricLoader = ">=0.14.8"
 
 [dependencies]
   fabric = "*"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     repositories {
         maven {
             name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
+            url = 'https://repository.hanbings.io/proxy'
         }
         mavenCentral()
         gradlePluginPortal()

--- a/src/main/java/committee/nova/minerslunchbox/MinersLunchbox.java
+++ b/src/main/java/committee/nova/minerslunchbox/MinersLunchbox.java
@@ -2,21 +2,24 @@ package committee.nova.minerslunchbox;
 
 import committee.nova.minerslunchbox.item.LunchboxItem;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.item.FoodComponent;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MinersLunchbox implements ModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Miner's Lunchbox");
-	public static final LunchboxItem LUNCHBOX = new LunchboxItem(new Item.Settings().food(new FoodComponent.Builder().build()).maxCount(1).group(ItemGroup.TOOLS));
+	public static final LunchboxItem LUNCHBOX = new LunchboxItem(new Item.Settings().food(new FoodComponent.Builder().build()).maxCount(1));
 
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.ITEM, new Identifier("minerslunchbox", "lunchbox"), LUNCHBOX);
+		Registry.register(Registries.ITEM, new Identifier("minerslunchbox", "lunchbox"), LUNCHBOX);
+		ItemGroupEvents.modifyEntriesEvent(ItemGroups.TOOLS).register(entries -> entries.add(LUNCHBOX));
 		LOGGER.info("Initialized.");
 	}
 }


### PR DESCRIPTION
因为 fabric api 修改了物品注册方式 使其能适配 >= 1.19.3 版本
Because the Fabric API modifies the way items are registered, it adapts to version >= 1.19.3